### PR TITLE
Fix swapped ZWNJ/ZWJ descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ ZWT (zero width text) is an invisible string encoding that allows embedding any 
 
 - ZWT (zero-width-text) consists of the following three types of zero-width characters:
   - `U+200B` ZWSP (zero width space)
-  - `U+200C` ZWJ (zero width joiner)
-  - `U+200D` ZWNJ (zero width non-joiner)
+  - `U+200C` ZWNJ (zero width non-joiner)
+  - `U+200D` ZWJ (zero width joiner)
 - The structure of the zero width text string is `ZWNJ 1* ( 8 ( ZWSP / ZWJ ) ) ZWNJ`
   - Zero width text is intended to be embedded mainly at the boundaries of documents or words, so it is surrounded by `ZWNJ` to prevent unintended joining of adjacent characters with `ZWJ`.
   - The data part of the zero width text is a simple replacement of the bits 0/1 of the original data with the two characters `ZWSP` and `ZWJ`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zwtext | ZWT (Zero Width Text) encoder and decorder
+# zwtext | ZWT (Zero Width Text) encoder and decoder
 
 ZWT (zero width text) is an invisible string encoding that allows embedding any data into text without visually affecting it, by utilizing zero-width characters in UNICODE.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zwtext",
   "version": "1.0.3",
-  "description": "ZWT (Zero Width Text) encoder and decorder",
+  "description": "ZWT (Zero Width Text) encoder and decoder",
   "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
U+200C is ZWNJ (zero width non-joiner) and U+200D is ZWJ (zero width joiner),
but the README had them reversed.

https://claude.ai/code/session_016gzs8McHHSz7NZtMA9gQGa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* README の ZWT 仕様をアップデートし、U+200C を ZWNJ (ゼロ幅非接合子)、U+200D を ZWJ (ゼロ幅接合子) として正しく表記しました
* README のトップレベルヘッダーの綴り間違いを修正しました

## チョア
* パッケージメタデータの説明文の綴り間違いを修正しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->